### PR TITLE
fix: enforce getting a json response from the API

### DIFF
--- a/lib/calendarific/apis/holidays.ex
+++ b/lib/calendarific/apis/holidays.ex
@@ -4,7 +4,7 @@ defmodule Calendarific.Apis.Holidays do
   alias Calendarific.HttpClient
   alias Calendarific.Types
 
-  @endpoint "holidays"
+  @endpoint "holidays/json"
 
   @spec fetch(params) :: {:ok, list(Holiday)} | {:error, any()}
         when params: %{


### PR DESCRIPTION
We sometimes get HTML responses from the API. According to the docs, we can enforce getting a JSON response by adding `/json` to an endpoint.

> JSON Response
> We try to automatically detect when someone wants to call our API vs view our website, and send back the appropriate JSON response rather than HTML. We do this based on the user agent for known popular programming languages, tools and frameworks. There are a couple of other ways to force a JSON response from us in the cases that it doesn't happen automatically though. One is to add /json to the URL, and the other is to set an accepts header to application/json: